### PR TITLE
Base apimachinery branch for 1.18.0-beta.2

### DIFF
--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -115,6 +115,7 @@ func (m *DefaultRESTMapper) AddSpecific(kind schema.GroupVersionKind, plural, si
 // callers to use the RESTMapper they mean.
 var unpluralizedSuffixes = []string{
 	"endpoints",
+	"securitycontextconstraints",
 }
 
 // UnsafeGuessKindToResource converts Kind to a resource name.


### PR DESCRIPTION
see [1.18 pick spreadsheet](https://docs.google.com/spreadsheets/d/1caKr7-FGn14H2P8UZ6K7wrjcqwQIRuEA_nQR8X4iKJ0/edit#gid=1354624919)

Previous base PR: https://github.com/openshift/kubernetes-apimachinery/pull/5

Following https://github.com/openshift/enhancements/blob/master/enhancements/oc/upgrade_kubernetes.md