### PR TITLE
UPSTREAM: <carry>: client-go: unpluralized SCC

### DIFF
--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -115,6 +115,7 @@ func (m *DefaultRESTMapper) AddSpecific(kind schema.GroupVersionKind, plural, si
 // callers to use the RESTMapper they mean.
 var unpluralizedSuffixes = []string{
 	"endpoints",
+	"securitycontextconstraints",
 }
 
 // UnsafeGuessKindToResource converts Kind to a resource name.


### PR DESCRIPTION
[1.19 pick list](https://docs.google.com/spreadsheets/d/1R_NK2gmx9BTIM92qewjgET-m8jQ9NCgSZedUiNSDQYY/edit#gid=1354624919)

Previous base PR https://github.com/openshift/kubernetes-apimachinery/pull/8

Following https://github.com/openshift/enhancements/blob/master/enhancements/oc/upgrade_kubernetes.md