### PR TITLE
UPSTREAM: <carry>: client-go: unpluralized SCC

### DIFF
--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -118,6 +118,7 @@ func (m *DefaultRESTMapper) AddSpecific(kind schema.GroupVersionKind, plural, si
 // callers to use the RESTMapper they mean.
 var unpluralizedSuffixes = []string{
 	"endpoints",
+	"securitycontextconstraints",
 }
 
 // UnsafeGuessKindToResource converts Kind to a resource name.


### PR DESCRIPTION
Kubernetes-commit: 963d393a6e3deb12b0adec19c16df9280ef0e1de